### PR TITLE
fix default code-styling color

### DIFF
--- a/github.css
+++ b/github.css
@@ -18,6 +18,7 @@ body {
 }
 
 .vscode-dark code > div {
+	color: #333;
 	background-color: #f7f7f7;
 }
 


### PR DESCRIPTION
without this fix, the default color of code block is light-grey, not visible enough.